### PR TITLE
# Remove artifact attestation step from Docker image publishing workflow

### DIFF
--- a/.github/workflows/publish-docker-image.yaml
+++ b/.github/workflows/publish-docker-image.yaml
@@ -1,12 +1,16 @@
 name: Publish Docker image
 
+
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Versioning Release"]
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   push_to_registries:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/versioning-release.yaml
+++ b/.github/workflows/versioning-release.yaml
@@ -1,0 +1,18 @@
+name: Versioning Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  versioning:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+
+      - name: Assign Version
+        uses: huggingface/semver-release-action@1a164868d29fb12acd39d70e8e47326db9d78ad2


### PR DESCRIPTION
Eliminate the artifact attestation generation step from the Docker image publishing process to streamline the CI workflow. This change simplifies the deployment process by removing unnecessary complexity while retaining the essential metadata tagging functionality.