### PR TITLE
# Update versioning release action to use DarkMatterProductions repository

### DIFF
--- a/.github/workflows/versioning-release.yaml
+++ b/.github/workflows/versioning-release.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
 
       - name: Assign Version
-        uses: huggingface/semver-release-action@1a164868d29fb12acd39d70e8e47326db9d78ad2
+        uses: DarkMatterProductions/semver-release-action@1a164868d29fb12acd39d70e8e47326db9d78ad2


### PR DESCRIPTION
Change the versioning release action in the CI workflow to utilize the DarkMatterProductions version of the semver-release-action, ensuring compatibility and alignment with current project standards.