### PR TITLE
# Enhance release workflow to fetch tags during checkout

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6.0.1
+        with:
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
Update the release workflow configuration to include fetching tags during the checkout step, ensuring that all relevant tags are available for subsequent steps in the workflow.

# Change Details
* `release-workflow.yaml`
  * Add `fetch-tags: true` to the checkout step to enable tag fetching - Fixes #5 