### PR TITLE
# Refactor release workflow to improve job organization and streamline permissions 

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  version:
+  assign-version:
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -38,37 +38,49 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 semver.py
 
-      - name: Log in to Docker Hub
-        uses: DarkMatterProductions/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: assign-version
+    permissions:
+      packages: write
+      contents: write
+      attestations: write
+      id-token: write
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v6
 
-      - name: Log in to the Container registry
-        uses: DarkMatterProductions/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Log in to Docker Hub
+          uses: DarkMatterProductions/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: DarkMatterProductions/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          tags: |
-            type=pep440,pattern={{version}}
-            type=pep440,pattern={{major}}.{{minor}}
-            type=pep440,pattern={{version}}-python3-trixie-slim
-            type=pep440,pattern={{major}}.{{minor}}-python3-trixie-slim
-          images: |
-            ralnoc/vintagestory
-            ghcr.io/${{ github.repository }}
+        - name: Log in to the Container registry
+          uses: DarkMatterProductions/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker images
-        id: push
-        uses: DarkMatterProductions/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: DarkMatterProductions/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+          with:
+            tags: |
+              type=pep440,pattern={{version}}
+              type=pep440,pattern={{major}}.{{minor}}
+              type=pep440,pattern={{version}}-python3-trixie-slim
+              type=pep440,pattern={{major}}.{{minor}}-python3-trixie-slim
+            images: |
+              ralnoc/vintagestory
+              ghcr.io/${{ github.repository }}
+
+        - name: Build and push Docker images
+          id: push
+          uses: DarkMatterProductions/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+          with:
+            context: .
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Refactor the release workflow by renaming the version job to assign-version for clarity and restructuring the publish-release job to ensure it depends on the assign-version job. This enhances the organization of the workflow and clarifies the sequence of operations. Additionally, permissions for the publish-release job have been explicitly defined to ensure proper access control during execution.