### PR TITLE
fix: Update Container Image tagging order. Github Issue: #41

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -83,11 +83,11 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: |
-            ralnoc/vintagestory:latest
-            ralnoc/vintagestory:${{ steps.VintageStoryVersion.outputs.version }}
             ralnoc/vintagestory:${{ needs.assign-version.outputs.version }}
             ralnoc/vintagestory:${{ needs.assign-version.outputs.version }}-python3-trixie-slim
-            ghcr.io/${{steps.toLowerCase.outputs.repository}}:latest
-            ghcr.io/${{steps.toLowerCase.outputs.repository}}:${{ steps.VintageStoryVersion.outputs.version }}
+            ralnoc/vintagestory:${{ steps.VintageStoryVersion.outputs.version }}
+            ralnoc/vintagestory:latest
             ghcr.io/${{steps.toLowerCase.outputs.repository}}:${{ needs.assign-version.outputs.version }}
             ghcr.io/${{steps.toLowerCase.outputs.repository}}:${{ needs.assign-version.outputs.version }}-python3-trixie-slim
+            ghcr.io/${{steps.toLowerCase.outputs.repository}}:${{ steps.VintageStoryVersion.outputs.version }}
+            ghcr.io/${{steps.toLowerCase.outputs.repository}}:latest


### PR DESCRIPTION
Resolves issue of latest and server version not being the first two items on the tagging list within Docker Hub.