### PR TITLE
# Update Vintage Story version handling to use stable version

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -80,7 +80,7 @@ jobs:
         run: echo "repository=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
 
       - id: VintageStoryVersion
-        run: f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; print(vs_version_yaml['vs_version']) ; f.close() >> $GITHUB_OUTPUT
+        run: f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; print(vs_version_yaml['vs_stable_version']) ; f.close() >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
         id: push


### PR DESCRIPTION
Corrected the version retrieval logic to read the stable version from the configuration file, ensuring accurate version tagging for releases.

# Change Details
* `release-workflow.yaml`
  * Modify version retrieval to use 'vs_stable_version' instead of 'vs_version' from the YAML configuration file - fixes #52 