### PR TITLE
# Fix syntax error in release workflow for Vintage Story version retrieval 

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -80,7 +80,7 @@ jobs:
         run: echo "repository=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
 
       - id: VintageStoryVersion
-        run: f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; print(vs_version_yaml['vs_stable_version']) ; f.close() >> $GITHUB_OUTPUT
+        run: python3 -c "import yaml ; f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; print(vs_version_yaml['vs_stable_version']) ; f.close()" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
         id: push


### PR DESCRIPTION
- fixes #54 : Correct the syntax in the release workflow YAML file to properly execute a Python command for retrieving the stable version of Vintage Story from the YAML configuration file.