### PR TITLE
# Update Vintage Story version retrieval in release workflow 

### DIFF
--- a/.github/workflows/release-workflow.yaml
+++ b/.github/workflows/release-workflow.yaml
@@ -80,7 +80,7 @@ jobs:
         run: echo "repository=${{ github.repository }}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_OUTPUT
 
       - id: VintageStoryVersion
-        run: python3 -c "import yaml ; f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; print(vs_version_yaml['vs_stable_version']) ; f.close()" >> $GITHUB_OUTPUT
+        run: python3 -c "import yaml ; f = open('vintage-story-version.yaml', 'r') ; vs_version_yaml = yaml.safe_load(f) ; stable_version = vs_version_yaml['vs_stable_version'] ; print(f'version={stable_version}') ; f.close()" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker images
         id: push


### PR DESCRIPTION
Refactor the Vintage Story version retrieval command in the release workflow to format the output correctly, ensuring the stable version is prefixed with "version=" for proper parsing in subsequent steps.

# Change Details
* `release-workflow.yaml` - fixes #56
  * Modify the command for retrieving the stable version from the YAML file to include a formatted output with "version=" prefix.