### PR TITLE
fix/resolve-order: Add requirements.txt for vintage_rcon_client and update Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,8 @@ RUN wget -P ${VSPATH} https://cdn.vintagestory.at/gamefiles/stable/vs_server_lin
     rm ${VSPATH}/vs_server_linux-x64_${VS_VERSION}.tar.gz && \
     chown -R ${USERNAME}: ${HOMEPATH}
 
+COPY vintage_rcon_client/requirements.txt /vintage_rcon_client/requirements.txt
+
 RUN python -m pip install --no-cache-dir -r "/vintage_rcon_client/requirements.txt" && \
     pip3 install --break-system-packages pyyaml
 


### PR DESCRIPTION
Added `requirements.txt` for the `vintage_rcon_client` to specify dependencies required for the client. Updated the `Dockerfile` to copy the `requirements.txt` into the image and install the listed Python packages using pip. fixes #59 