### PR TITLE
fix/allow-creative-mode-flag: Update Creative Mode flag handling in config generation 

### DIFF
--- a/generate-config.py
+++ b/generate-config.py
@@ -73,7 +73,7 @@ class VintageStoryConfig:
         """Generate config and apply overrides from environment variables."""
         if "VS_CFG_ALLOW_CREATIVE_MODE" in os.environ:
             print("Allowing Creative Mode")
-            self.config["WorldConfig"]["AllowCreativeMode"] = os.environ.pop("VS_CFG_ALLOW_CREATIVE_MODE").lower() in ("1", "true", "yes")
+            self.config["WorldConfig"]["AllowCreativeMode"] = self.convert_value(os.environ.pop("VS_CFG_ALLOW_CREATIVE_MODE").lower(), "boolean")
         overrides = {self.env_setting_map[env_key][0]: self.convert_value(os.environ[env_key], self.env_setting_map[env_key][1]) for env_key in os.environ.keys() if env_key.startswith("VS_CFG_")}
         self.config.update(overrides)
         if overrides:


### PR DESCRIPTION
This pull request updates the logic for applying environment variable overrides in the `generate_serverconfig` method, specifically improving how boolean values are handled.

Configuration override improvements: 

* Changed the assignment of `AllowCreativeMode` to use the `convert_value` method for boolean conversion, ensuring consistency with other environment variable overrides. (`generate-config.py`, [generate-config.pyL76-R76](diffhunk://#diff-4b485158502a931e1f3c673aae9d2cab36fbe252b4d1555fe262decbd33d854aL76-R76))Refactor the handling of the "AllowCreativeMode" configuration to utilize a dedicated conversion method for environment variable values. This change ensures that the value is correctly interpreted as a boolean, enhancing the robustness of the configuration generation process. [ fixes #66 ] 