### PR TITLE
Enhance version argument handling and automate GitHub Release

### DIFF
--- a/build-dev.sh
+++ b/build-dev.sh
@@ -185,15 +185,22 @@ check_vars() {
   return 0
 }
 
-ARG_1=$1
-ARG_2=$2
-RAW_VS_VERSION=$ARG_1
+## Script Code Starts Here
 
-if [[ "${ARG_1}" == "stable" ]]; then
-  RAW_VS_VERSION=$(curl -s https://api.vintagestory.at/lateststable.txt)
+VS_VERSION_ARG=$1
+ARG_2=$2
+
+if [[ -z "${VS_VERSION_ARG}" ]]; then
+  INDENT=$(printf -- ' %.0s' {1..27})
+  error_string "${RED}Argument required. Syntax: $(basename $0) [stable|unstable]\n${INDENT}$(basename $0) <VS-version> <state-metadata[stable|unstable]>${NC}"
+  exit 1
+fi
+
+if [[ "${VS_VERSION_ARG}" == "stable" ]]; then
+  IDENTIFIED_VS_VERSION=$(curl -s https://api.vintagestory.at/lateststable.txt)
   VS_VERSION_STATE="stable"
-elif [[ "${ARG_1}" == "unstable" ]]; then
-  RAW_VS_VERSION=$(curl -s https://api.vintagestory.at/latestunstable.txt)
+elif [[ "${VS_VERSION_ARG}" == "unstable" ]]; then
+  IDENTIFIED_VS_VERSION=$(curl -s https://api.vintagestory.at/latestunstable.txt)
   VS_VERSION_STATE="unstable"
 fi
 
@@ -203,7 +210,7 @@ elif [[ "${ARG_2}" == "unstable" ]]; then
   VS_VERSION_STATE="unstable"
 fi
 
-if [ ! -z "${RAW_VS_VERSION+x}" ] && [[ $RAW_VS_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+if [ ! -z "${IDENTIFIED_VS_VERSION+x}" ] && [[ $IDENTIFIED_VS_VERSION =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
   declare -A VS_VERSION_ARRAY=(
     [MAJOR]=${BASH_REMATCH[1]}
     [MINOR]=${BASH_REMATCH[2]}

--- a/build-release.sh
+++ b/build-release.sh
@@ -290,6 +290,28 @@ for repo in "${REPOSITORIES[@]}"; do
   fi
 done
 
+step_header_string "Creating GitHub Release"
+action_string "Creating GitHub Release for tag: ${LAVENDER}${DOCKER_VERSION_NEW}${NC}"
+RELEASE_NOTES="## Vintage Story Docker Image Release
+
+**Vintage Story Version:** \`${VS_VERSION}\`
+**Docker Image Version:** \`${DOCKER_VERSION_NEW}\`
+**Release State:** \`${VS_VERSION_STATE}\`
+
+### Docker Image Tags
+$(for tag in "${TAG_MATRIX[@]}"; do echo "- \`${tag}\`"; done)
+$(if [[ "${VS_VERSION_STATE}" == "stable" ]]; then echo "- \`latest\`"; fi)
+
+### Available Repositories
+$(for repo in "${REPOSITORIES[@]}"; do echo "- \`${repo}\`"; done)"
+
+GH_TOKEN="${GHCR_TOKEN}" execute "Creating GitHub Release: ${LAVENDER}${DOCKER_VERSION_NEW}${NC}" \
+  gh release create "${DOCKER_VERSION_NEW}" \
+    --title "Vintage Story ${VS_VERSION} (Docker ${DOCKER_VERSION_NEW})" \
+    --notes "${RELEASE_NOTES}" \
+    $(if [[ "${VS_VERSION_STATE}" == "unstable" ]]; then echo "--prerelease"; fi)
+
+step_footer_string
 step_header_string "Build Cleanup"
 execute "Pruning unused images" docker image prune -f
 execute "Removing ${LAVENDER}build.env${NC} File" rm build.env

--- a/build-release.sh
+++ b/build-release.sh
@@ -192,6 +192,12 @@ check_vars() {
 VS_VERSION_ARG=$1
 ARG_2=$2
 
+if [[ -z "${VS_VERSION_ARG}" ]]; then
+  INDENT=$(printf -- ' %.0s' {1..27})
+  error_string "${RED}Argument required. Syntax: $(basename $0) [stable|unstable]\n${INDENT}$(basename $0) <VS-version> <state-metadata[stable|unstable]>${NC}"
+  exit 1
+fi
+
 if [[ "${VS_VERSION_ARG}" == "stable" ]]; then
   IDENTIFIED_VS_VERSION=$(curl -s https://api.vintagestory.at/lateststable.txt)
   VS_VERSION_STATE="stable"


### PR DESCRIPTION
## Summary

Adds an automated GitHub Release creation step to `build-release.sh`, triggered after all Docker images have been published to their respective repositories.

## Changes

### `build-release.sh`
- Added a new **"Creating GitHub Release"** step after the image publishing loop.
- Dynamically generates release notes including:
  - Vintage Story version
  - Docker image version
  - Release state (`stable`/`unstable`)
  - Full list of Docker image tags published (including `latest` for stable releases)
  - List of target repositories
- Uses the `gh` CLI to create the release, tagging it with `DOCKER_VERSION_NEW`.
- Automatically marks the release as a **pre-release** when the version state is `unstable`.
- Reuses the existing `GHCR_TOKEN` for GitHub CLI authentication via `GH_TOKEN`.

## Behavior

| Condition | Result |
|---|---|
| `VS_VERSION_STATE=stable` | Full release, includes `latest` tag in notes |
| `VS_VERSION_STATE=unstable` | Pre-release (`--prerelease` flag passed to `gh`) |

## Testing

- Verify `gh` CLI is authenticated and available in the build environment.
- Confirm release appears on GitHub after a successful build run.
- Validate pre-release flag is set correctly for unstable builds.