### PR TITLE
refactor(config): add color output utilities and update config generation

### DIFF
--- a/.continue/mcpServers/local-system-servers.yaml
+++ b/.continue/mcpServers/local-system-servers.yaml
@@ -1,0 +1,15 @@
+﻿name: Local System MCP Servers
+version: 1.0.0
+schema: v1
+mcpServers:
+  - name: filesystem
+    command: "C:/Program Files/nodejs/node.exe"
+    args:
+      - "C:/Users/drahk/AppData/Roaming/npm/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js"
+      - "C:/Users/drahk/IdeaProjects/vintagestory_docker"
+  - name: memory
+    command: "C:/Program Files/nodejs/node.exe"
+    args:
+      - "C:/Users/drahk/AppData/Roaming/npm/node_modules/@modelcontextprotocol/server-memory/dist/index.js"
+    env:
+      MEMORY_FILE_PATH: "C:/Users/drahk/.mcp-data/memory.json"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -130,7 +130,7 @@ if [[ "${VS_RCON_ENABLED}" == true ]]; then
   CURR_DIR=$(pwd)
   cd /vintage_rcon_client
   python ./generate_vsrcon_config.py -f /vintagestory/data/ModConfig/vsrcon.json
-  python ./generate_vsrconclient_config.py -f /vintage_rcon_client/client-config.yaml
+  python ./generate_vsrconclient_config.py -f /vintage_rcon_client/client-config.yaml --monochrome
   cd ${CURR_DIR}
 else
   echo "RCON mod not enabled, skipping download."

--- a/toolslib/output.py
+++ b/toolslib/output.py
@@ -1,0 +1,299 @@
+import re
+import sys
+from subprocess import CompletedProcess
+from typing import Callable, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Core helper — 256-color ANSI wrapper (replaces the old 8-color _wrap_with)
+# ---------------------------------------------------------------------------
+
+def c(code: int, payload: str) -> str:
+    """
+    Wrap text with 256-color ANSI coloring.
+
+    :param code: 256-color ANSI color code (0-255)
+    :param payload: text to colorize immediately
+    :return: returns a colored ANSI string
+    """
+    start = f"\033[38;5;{code}m"
+    end = "\033[0m"
+
+    result: str
+    if not isinstance(payload, str):
+        payload = str(payload)
+
+    if "\033[" in payload:
+        # Nested coloring — reapply outer color after every inner reset
+        result = f"{start}{payload.replace(end, end + start)}{end}"
+    else:
+        result = f"{start}{payload}{end}"
+    return result
+
+def c_subprocess(code: int, payload: Tuple[Callable, Tuple]) -> CompletedProcess:
+    """
+    Wrap text with 256-color ANSI coloring.
+
+    :param code: 256-color ANSI color code (0-255)
+    :param payload: a function that requires
+                    deferred RESET handling (e.g. For Direct TTY prompts).
+                    Expected structure:
+                      - Tuple[Callable, Tuple[Any]]: treated as (function, args)
+                        to call with function(*args) and color active during execution
+    :return: the result of calling the provided function with the appropriate
+             coloring applied as a wrapper to ensure the color is active during
+             the function's execution and properly reset afterward.
+    """
+    start = f"\033[38;5;{code}m"
+    end = "\033[0m"
+
+    print(start, end="", flush=True)
+    result: CompletedProcess = payload[0](*payload[1])
+    print(end, end="", flush=True)
+    return result
+
+
+def strip_ansi_color_codes(text: str) -> str:
+    """
+    Removes ANSI escape sequences from a string.
+
+    :param text: The string to strip ANSI color codes from.
+    :return: The string with ANSI color codes removed.
+    """
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    return ansi_escape.sub('', text)
+
+
+def clear_previous_lines(n: int, stream=sys.stdout, count_current_line: bool = True) -> None:
+    """Move cursor up n lines, erasing each one."""
+    if count_current_line:
+        n += 1
+
+    for _ in range(n):
+        stream.write('\033[1A'  # move cursor up one line
+                     '\033[2K') # erase entire line
+    stream.flush()
+
+
+RESET = "\033[0m"
+
+# ---------------------------------------------------------------------------
+# Gradient color tables (matching shell script palette exactly)
+# ---------------------------------------------------------------------------
+
+PURPLE_CODES = (54, 54, 91, 91, 129, 129, 171, 171)   # dark → light
+BLUE_CODES   = (17, 17, 18, 19, 19, 20, 21, 21)        # navy → cyan-blue
+
+# ---------------------------------------------------------------------------
+# Retained unicode emoji variables
+# ---------------------------------------------------------------------------
+
+success = "\U00002705"
+failed  = "\U0000274C"
+warning = "\U000026A0"
+
+# ---------------------------------------------------------------------------
+# Gradient helper
+# ---------------------------------------------------------------------------
+
+def _gradient_str(text: str, *codes: int) -> str:
+    """Spread color codes evenly across the characters of text."""
+    length = len(text)
+    if length == 0:
+        return ""
+    num_colors = len(codes)
+    result = {}
+    for i, ch in enumerate(text):
+        ci = i * (num_colors - 1) // (length - 1 if length > 1 else 1)
+        result[codes[ci]] = ch + result.get(codes[ci], "")
+    return "".join([c(segment_color, segment_text) for segment_color, segment_text in result.items()])
+
+
+# ---------------------------------------------------------------------------
+# Header / footer builders (return str — callers decide when to print)
+# ---------------------------------------------------------------------------
+
+def section_header_string(title: str) -> str:
+    """Purple gradient 80-char section header."""
+    title_padded = f" {title} "
+    total = 80
+    prefix_eq = 5
+    suffix_eq = total - prefix_eq - len(title_padded)
+    if suffix_eq < 0:
+        suffix_eq = 0
+    prefix = _gradient_str("=" * prefix_eq, *PURPLE_CODES)
+    suffix = _gradient_str("=" * suffix_eq, *reversed(PURPLE_CODES))
+    return f"{prefix}{c(105, title_padded)}{suffix}"
+
+
+def section_footer_string() -> str:
+    """Full-width purple gradient footer bar (mirrors shell script exactly)."""
+    total = 80
+    prefix_eq = 5
+    suffix_eq = total - prefix_eq // 2   # = 78; total printed chars = 83 (matches shell)
+    prefix = _gradient_str("=" * prefix_eq, *PURPLE_CODES)
+    suffix = _gradient_str("=" * suffix_eq, *reversed(PURPLE_CODES))
+    return f"{prefix}{suffix}"
+
+
+def step_header_string(title: str) -> str:
+    """Blue gradient 80-char step header."""
+    title_padded = f" {title} "
+    total = 80
+    prefix_eq = 5
+    suffix_eq = total - prefix_eq - len(title_padded)
+    if suffix_eq < 0:
+        suffix_eq = 0
+    prefix = _gradient_str("=" * prefix_eq, *BLUE_CODES)
+    suffix = _gradient_str("=" * suffix_eq, *reversed(BLUE_CODES))
+    return f"{prefix}{c(184, title_padded)}{suffix}"
+
+
+def step_footer_string() -> str:
+    """Full-width blue gradient footer bar (mirrors shell script exactly)."""
+    total = 80
+    prefix_eq = 5
+    suffix_eq = total - prefix_eq // 2   # = 78; total printed chars = 83 (matches shell)
+    prefix = _gradient_str("=" * prefix_eq, *BLUE_CODES)
+    suffix = _gradient_str("=" * suffix_eq, *reversed(BLUE_CODES))
+    return f"{prefix}{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# 256-color palette grid
+# ---------------------------------------------------------------------------
+
+def _ansi_256_to_rgb(n: int) -> tuple[int, int, int]:
+    """Approximate the RGB value of a 256-color ANSI index.
+
+    The palette has three regions:
+      0–15   : standard/system colors (hardcoded approximations)
+      16–231 : 6×6×6 color cube
+      232–255: 24-step grayscale ramp
+    """
+    if n < 16:
+        standard = [
+            (0,   0,   0  ), (128, 0,   0  ), (0,   128, 0  ), (128, 128, 0  ),
+            (0,   0,   128), (128, 0,   128), (0,   128, 128), (192, 192, 192),
+            (128, 128, 128), (255, 0,   0  ), (0,   255, 0  ), (255, 255, 0  ),
+            (0,   0,   255), (255, 0,   255), (0,   255, 255), (255, 255, 255),
+        ]
+        return standard[n]
+    elif n < 232:
+        idx = n - 16
+        b = idx % 6
+        g = (idx // 6) % 6
+        r = idx // 36
+        def _v(x: int) -> int:
+            return 0 if x == 0 else 55 + x * 40
+        return _v(r), _v(g), _v(b)
+    else:
+        val = 8 + (n - 232) * 10
+        return val, val, val
+
+
+def _contrast_fg(n: int) -> int:
+    """Return ANSI color 0 (black) or 15 (white), whichever contrasts better against n."""
+    r, g, b = _ansi_256_to_rgb(n)
+    luminance = 0.299 * r + 0.587 * g + 0.114 * b
+    return 0 if luminance > 128 else 15
+
+
+def print_color_palette(show_block: bool = False, background: bool = False) -> None:
+    """Print all 256 ANSI colors in a 16×16 grid.
+
+    Each cell shows the color index styled in that color.
+
+    :param show_block: When True, prefix each foreground cell with a '██'
+                       swatch in the same color, making the grid wider but
+                       easier to read. Ignored when background=True, since
+                       the fill already acts as the swatch.
+    :param background: When True, render each color as a background fill
+                       instead of foreground text. The number is drawn in
+                       black or white, whichever contrasts better.
+
+    Cell anatomy (visible chars):
+      foreground, no block : ' NNN '   (5 chars)
+      foreground, block    : '██ NNN ' (8 chars)
+      background           : ' NNN '   (5 chars, highlighted)
+    """
+    for i in range(256):
+        num = f" {i:>3} "          # always ' NNN ' — consistent 5-char number field
+        block = "██ "              # 3-char swatch prefix (foreground mode only)
+
+        if background:
+            bg  = f"\033[48;5;{i}m"
+            fg  = f"\033[38;5;{_contrast_fg(i)}m"
+            cell = f"{bg}{fg}{num}{RESET}"
+        else:
+            fg = f"\033[38;5;{i}m"
+            if show_block:
+                cell = f"{fg}{block}{num}{RESET}"
+            else:
+                cell = f"{fg}{num}{RESET}"
+
+        print(cell, end="")
+        if (i + 1) % 16 == 0:
+            print()
+
+
+# ---------------------------------------------------------------------------
+# Print functions (side-effect only; no return value)
+# ---------------------------------------------------------------------------
+def string_printer(code: int) -> Callable[[str], str]:
+    """Return a function that prints a message in the specified color code."""
+    def printer(msg: str):
+        return f"{c(code, msg)}"
+    return printer
+
+
+def prompt_string(msg: str) -> str:
+    """Return a colorized prompt string for use with getpass.getpass(prompt=...)."""
+    return string_printer(75)(msg)
+
+
+def action_string(msg: str) -> str:
+    return string_printer(75)(msg)
+
+
+def success_string(msg: str) -> str:
+    return string_printer(120)(msg)
+
+
+def warning_string(msg: str) -> str:
+    return string_printer(221)(msg)
+
+
+def error_string(msg: str) -> str:
+    return string_printer(210)(msg)
+
+
+def standard_string(msg: str) -> str:
+    return f"{RESET}{msg}"
+
+
+def blank_string() -> str:
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Smoke-test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":  # pragma: no cover
+    print(section_header_string("Section Header Example"))
+    print(section_footer_string())
+    print(step_header_string("Step Header Example"))
+    print(step_footer_string())
+    print(action_string("This is an action message"))
+    print(success_string(f"This is a success message {success}"))
+    print(warning_string(f"This is a warning message {warning}"))
+    print(error_string(f"This is an error message {failed}"))
+    print(standard_string("This is a standard message"))
+    blank_string()
+
+    print(section_header_string("Foreground — numbers only"))
+    print_color_palette()
+    blank_string()
+    print(section_header_string("Background"))
+    print_color_palette(background=True)

--- a/vintage_rcon_client/app.py
+++ b/vintage_rcon_client/app.py
@@ -4,6 +4,7 @@ Async Application with FastAPI and python-socketio
 JWT-based authentication for unified session management
 """
 import sys
+from argparse import Namespace
 
 import yaml
 import logging
@@ -25,6 +26,8 @@ from authlib.integrations.starlette_client import OAuth
 import uvicorn
 from jose import JWTError, jwt
 from passlib.context import CryptContext
+
+from output import strip_ansi_color_codes, color_action, color_action_var
 
 # Initialize SocketIO server with asyncio support
 sio = socketio.AsyncServer(
@@ -847,9 +850,29 @@ async def handle_rcon_status(sid):
         }, to=sid)
 
 
+def display_configs(args: Namespace, cfg, prefix="", indent=0):
+    """Recursively iterate over config and apply env_override for each leaf item."""
+    for key, value in cfg.items():
+        key_path = f"{prefix}_{key}" if prefix else key
+        msg = color_action(f"{' ' * indent * 2}Processing config key: {color_action_var(key_path)}")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+        if isinstance(value, dict):
+            msg = color_action(f"{' ' * indent * 2}Recursing into nested config for key: {color_action_var(key_path)}")
+            print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+            display_configs(args, value, key_path, indent=indent + 1)
+        else:
+            if logger.getEffectiveLevel() == logging.DEBUG:
+                msg = color_action(f"{' ' * indent * 2}Key Value: {color_action_var(key_path)} with the value: {color_action_var(value)}")
+                print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+            else:
+                msg = color_action(f"{' ' * indent * 2}Key Value: {color_action_var(key_path)}")
+                print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+
+
 def run():
     """Run the FastAPI application with uvicorn"""
     load_config()
+    display_configs(args=Namespace(monochrome=False), cfg=config)
 
     host = config.get('server', {}).get('host', '0.0.0.0')
     port = config.get('server', {}).get('port', 5000)

--- a/vintage_rcon_client/generate_vsrconclient_config.py
+++ b/vintage_rcon_client/generate_vsrconclient_config.py
@@ -1,24 +1,31 @@
 import argparse
 import logging
 import os
+from argparse import Namespace
 from pathlib import Path
 from traceback import format_exc
 
 import yaml
 
 from output import step_header_string, color_action, color_action_var, \
-    section_header_string, color_error, color_success, step_footer_string, section_footer_string
+    section_header_string, color_error, color_success, step_footer_string, section_footer_string, strip_ansi_color_codes
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def env_override(key_path, default_value, full_key_name=False):
-    """Get config value from environment variable or use default"""
-    if full_key_name:
-        env_key = key_path.upper()
+def env_override(args: Namespace, key_path, default_value):
+    """Get config value from the environment variable or use default"""
+    # if full_key_name:
+    #     env_key = key_path.upper()
+    # else:
+    env_key = f"VS_RCON_CLIENT_CFG_{key_path.upper()}"
+    if logger.getEffectiveLevel() == logging.DEBUG:
+        msg = color_action(f"Checking environment variable: {color_action_var(env_key)} for config key: {color_action_var(key_path)} with default value: {color_action_var(default_value)}")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg)
     else:
-        env_key = f"VS_RCON_CLIENT_CFG_{key_path.upper()}"
+        msg = color_error(f"Environment variable {color_action_var(env_key)} not set, using default value: {color_action_var(default_value)}")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg)
     env_value = os.environ.get(env_key)
     if env_value is not None:
         # Convert string to appropriate type
@@ -31,39 +38,121 @@ def env_override(key_path, default_value, full_key_name=False):
         return env_value
     return default_value
 
-def apply_env_overrides(cfg, prefix="", indent=0):
+def apply_env_overrides(args: Namespace, cfg, prefix="", indent=0):
     """Recursively iterate over config and apply env_override for each leaf item."""
     for key, value in cfg.items():
         key_path = f"{prefix}_{key}" if prefix else key
-        print(color_action(f"{' ' * indent * 2}Processing config key: {color_action_var(key_path)}"))
+        msg = color_action(f"{' ' * indent * 2}Processing config key: {color_action_var(key_path)}")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg)
         if isinstance(value, dict):
-            print(color_action(f"{' ' * indent * 2}Recursing into nested config for key: {color_action_var(key_path)}"))
-            apply_env_overrides(value, key_path, indent=indent + 1)
+            msg = color_action(f"{' ' * indent * 2}Recursing into nested config for key: {color_action_var(key_path)}")
+            print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+            apply_env_overrides(args, value, key_path, indent=indent + 1)
         else:
             if logger.getEffectiveLevel() == logging.DEBUG:
-                print(color_action(f"{' ' * indent * 2}Applying env override for key: {color_action_var(key_path)} with the value: {color_action_var(value)}"))
+                msg = color_action(f"{' ' * indent * 2}Applying env override for key: {color_action_var(key_path)} with the value: {color_action_var(value)}")
+                print(strip_ansi_color_codes(msg) if args.monochrome else msg)
             else:
-                print(color_action(f"{' ' * indent * 2}Applying env override for key: {color_action_var(key_path)}"))
-            cfg[key] = env_override(key_path, value, full_key_name=True if prefix else False)
+                msg = color_action(f"{' ' * indent * 2}Applying env override for key: {color_action_var(key_path)}")
+                print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+            cfg[key] = env_override(args, key_path, value)
 
 
-def load_config(config_path: Path):
+def generate_new_config(args: Namespace, config_path: Path):
+    msg = color_action(f"No existing configuration file found at: {color_action_var(str(config_path))}")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+    msg = color_action("Generating new configuration with default values...")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg, end="")
+    config = {
+        "server": {
+            "host": env_override(args, "server_host", "0.0.0.0"),
+            "port": env_override(args, "server_port", 5000),
+            "secret_key": env_override(args, "server_secret_key", "vintage-story-rcon-client-secret-key-change-me")
+        },
+        "rcon": {
+            "default_host": env_override(args, "rcon_default_host", "localhost"),
+            "default_port": env_override(args, "rcon_default_port", 42425),
+            "password": env_override(args, "rcon_password", "changeme"),
+            "locked_address": env_override(args, "rcon_locked_address", False),
+            "timeout": env_override(args, "rcon_timeout", 10),
+            "max_message_size": env_override(args, "rcon_max_message_size", 4096)
+        },
+        "security": {
+            "require_auth": env_override(args, "security_require_auth", True),
+            "traditional_login_enabled": env_override(args, "security_traditional_login_enabled", True),
+            "default_username": env_override(args, "security_default_username", "admin"),
+            "default_password": env_override(args, "security_default_password", "changeme"),
+            "max_login_attempts": env_override(args, "security_max_login_attempts", 5),
+            "lockout_duration": env_override(args, "security_lockout_duration", 300),
+            "oauth": {
+                "enabled": env_override(args, "security_oauth_enabled", False),
+                "authorized_emails": env_override(args, "security_oauth_authorized_emails", [
+                    "admin@example.com",
+                    "user@example.com"
+                ]),
+                "google": {
+                    "enabled": env_override(args, "security_oauth_google_enabled", True),
+                    "client_id": env_override(args, "security_oauth_google_client_id", "your-google-client-id.apps.googleusercontent.com"),
+                    "client_secret": env_override(args, "security_oauth_google_client_secret", "your-google-client-secret")
+                },
+                "facebook": {
+                    "enabled": env_override(args, "security_oauth_facebook_enabled", False),
+                    "client_id": env_override(args, "security_oauth_facebook_client_id", "your-facebook-app-id"),
+                    "client_secret": env_override(args, "security_oauth_facebook_client_secret", "your-facebook-app-secret")
+                },
+                "github": {
+                    "enabled": env_override(args, "security_oauth_github_enabled", False),
+                    "client_id": env_override(args, "security_oauth_github_client_id", "your-github-client-id"),
+                    "client_secret": env_override(args, "security_oauth_github_client_secret", "your-github-client-secret")
+                },
+                "apple": {
+                    "enabled": env_override(args, "security_oauth_apple_enabled", False),
+                    "client_id": env_override(args, "security_oauth_apple_client_id", "your-apple-service-id"),
+                    "client_secret": env_override(args, "security_oauth_apple_client_secret", "your-apple-client-secret"),
+                    "team_id": env_override(args, "security_oauth_apple_team_id", "your-apple-team-id"),
+                    "key_id": env_override(args, "security_oauth_apple_key_id", "your-apple-key-id")
+                }
+            }
+        },
+        "logging": {
+            "log_commands": env_override(args, "logging_log_commands", True),
+            "log_file": env_override(args, "logging_log_file", "logs/rcon.log"),
+            "log_level": env_override(args, "logging_log_level", "INFO")
+        }
+    }
+    msg = color_success(" Done.")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+    return config
+
+def load_config(args: Namespace, config_path: Path):
     config = {}
-    print(color_action(f"Checking on existing configuration file at: {color_action_var(str(config_path))}"))
+    msg = color_action(f"Checking on existing configuration file at: {color_action_var(str(config_path))}")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
     if config_path.exists():
-        print(color_action("Existing configuration file found, loading..."), end="")
+        msg = color_action("Existing configuration file found, loading...")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg, end="")
         try:
             with open(config_path, 'r') as f:
                 config = yaml.safe_load(f)
-            print(color_action(" Done."))
+            msg = color_success(" Done.")
+            print(strip_ansi_color_codes(msg) if args.monochrome else msg)
         except Exception as e:
-            print(color_error("Failed to load existing configuration file."))
-            print(color_error(format_exc()))
+            msg = color_error("Failed to load existing configuration file.")
+            print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+            msg = color_error(format_exc())
+            print(strip_ansi_color_codes(msg) if args.monochrome else msg)
             logger.error(f"Error loading configuration: {e}")
             raise
+    else:
+        msg = color_action("No existing configuration file found, generating new one...")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg, end="")
+        config = generate_new_config(args, config_path)
+        msg = color_success(" Done.")
+        print(strip_ansi_color_codes(msg) if args.monochrome else msg)
 
-    print(step_header_string("Applying environment variable overrides"))
-    apply_env_overrides(config)
+    msg = step_header_string("Applying environment variable overrides")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+    apply_env_overrides(args, config)
     return config
 
 def main():
@@ -101,6 +190,12 @@ Examples:
     )
 
     parser.add_argument(
+        '--monochrome',
+        action='store_true',
+        help='Disable colored output (useful for CI logs or terminals that do not support ANSI colors)'
+    )
+
+    parser.add_argument(
         '--loglevel',
         type=str,
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL','debug', 'info', 'warning', 'error', 'critical'],
@@ -112,16 +207,19 @@ Examples:
     if args.loglevel:
         logger.setLevel(getattr(logging, args.loglevel.upper(), logging.INFO))
 
-    print(section_header_string(f"Vintage Story RCon Client Configuration"))
+    msg = section_header_string(f"Vintage Story RCon Client Configuration")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
 
     config_path = Path(args.file)
-    config = load_config(config_path)
+    config = load_config(args, config_path)
 
     with open(config_path, 'w') as f:
         yaml.dump(config, f)
-    print(color_success(f"Configuration saved to {config_path}"))
-    print(step_footer_string())
-    print(section_footer_string())
+    msg = color_success(f"Configuration saved to {config_path}")
+    print(strip_ansi_color_codes(msg) if args.monochrome else msg)
+    if not args.monochrome:
+        print(step_footer_string())
+    print(strip_ansi_color_codes(section_footer_string()) if args.monochrome else section_footer_string())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request introduces improved configuration management, enhanced environment variable handling, and advanced colorized output utilities for the RCON client. The main changes include a refactor of how configuration files are loaded and overridden by environment variables, the addition of a `--monochrome` flag for colorless output, and a new `toolslib/output.py` utility for 256-color ANSI formatting and gradients. These changes improve usability, debugging, and CI compatibility.

**Configuration Management and Environment Variable Handling:**
- Refactored config loading and environment variable overrides in `generate_vsrconclient_config.py` to provide clearer, recursive application of environment variables, with detailed debug output and colorized messaging. Added a user-friendly config generation function and improved error handling.
- Added a `--monochrome` flag to both the config generator script and `app.py`, allowing all output to be displayed without ANSI color codes for better compatibility with CI systems and plain-text logs. [[1]](diffhunk://#diff-83fa759825624c94cc9a923dcace659b81cc77c9ab6f9c7617c7fff321206162R192-R197) [[2]](diffhunk://#diff-7bdaaae5248f0fbc8cae32f8493d0ed4affce3e85f9ec23f8914056312968b33R853-R875)

**Colorized and Monochrome Output Utilities:**
- Introduced the new `toolslib/output.py` module, providing 256-color ANSI formatting, color gradients, palette printing, and colorized string helpers for consistent, visually distinct output in both scripts and the main application.
- Updated key scripts and the main app to use shared color functions and to respect the `--monochrome` flag, ensuring all output (including recursive config display) can be colorized or plain as needed. [[1]](diffhunk://#diff-83fa759825624c94cc9a923dcace659b81cc77c9ab6f9c7617c7fff321206162R4-R28) [[2]](diffhunk://#diff-7bdaaae5248f0fbc8cae32f8493d0ed4affce3e85f9ec23f8914056312968b33R30-R31) [[3]](diffhunk://#diff-7bdaaae5248f0fbc8cae32f8493d0ed4affce3e85f9ec23f8914056312968b33R853-R875)

**Other Improvements:**
- Updated the Docker entrypoint to always pass the `--monochrome` flag to the config generator, ensuring compatibility with non-ANSI terminals.
- Added a local MCP servers YAML example for improved developer experience and local testing. (.continue/mcpServers/local-system-servers.yaml)

closes #71 